### PR TITLE
feat: Implement Anthropic Formatter (Step 1.2)

### DIFF
--- a/src/AgentScope.Core/Formatter/Anthropic/AnthropicBaseFormatter.cs
+++ b/src/AgentScope.Core/Formatter/Anthropic/AnthropicBaseFormatter.cs
@@ -1,0 +1,223 @@
+// Copyright 2024-2026 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AgentScope.Core.Formatter.Anthropic.Dto;
+using AgentScope.Core.Message;
+using AgentScope.Core.Model;
+
+namespace AgentScope.Core.Formatter.Anthropic;
+
+/// <summary>
+/// Abstract base formatter for Anthropic API with shared logic for handling Anthropic-specific requirements.
+/// Anthropic 基础格式化器
+/// 
+/// This class handles:
+/// - System message extraction and application (Anthropic requires system via system parameter)
+/// - Tool choice configuration with GenerateOptions
+/// 
+/// Java参考: io.agentscope.core.formatter.anthropic.AnthropicBaseFormatter
+/// </summary>
+public abstract class AnthropicBaseFormatter
+{
+    /// <summary>
+    /// Default max tokens for Anthropic API (required parameter)
+    /// </summary>
+    protected const int DefaultMaxTokens = 4096;
+
+    /// <summary>
+    /// Format messages to Anthropic request.
+    /// 格式化消息为 Anthropic 请求
+    /// </summary>
+    /// <param name="messages">AgentScope messages</param>
+    /// <param name="options">Generation options</param>
+    /// <returns>Anthropic request</returns>
+    public virtual AnthropicRequest Format(List<Msg> messages, GenerateOptions? options = null)
+    {
+        // Extract system message (Anthropic uses separate system parameter)
+        var systemMessages = AnthropicMessageConverter.ExtractSystemMessage(messages);
+
+        // Convert remaining messages
+        var filteredMessages = messages;
+        if (systemMessages != null && messages.Count > 0 && messages[0].Role == "system")
+        {
+            // Skip first system message as it's extracted to system parameter
+            filteredMessages = messages.Skip(1).ToList();
+        }
+
+        var anthropicMessages = AnthropicMessageConverter.Convert(filteredMessages);
+
+        // Build request
+        var request = new AnthropicRequest
+        {
+            Model = GetModelName(options),
+            Messages = anthropicMessages,
+            System = systemMessages,
+            MaxTokens = options?.MaxTokens ?? DefaultMaxTokens
+        };
+
+        // Apply generation options
+        request = ApplyOptions(request, options);
+
+        return request;
+    }
+
+    /// <summary>
+    /// Parse Anthropic response to ChatResponse.
+    /// 解析 Anthropic 响应
+    /// </summary>
+    /// <param name="response">Anthropic response</param>
+    /// <param name="startTime">Request start time</param>
+    /// <returns>AgentScope ChatResponse</returns>
+    public virtual Model.ChatResponse Parse(AnthropicResponse response, DateTime startTime)
+    {
+        return AnthropicResponseParser.ParseMessage(response, startTime);
+    }
+
+    /// <summary>
+    /// Get model name from options or use default.
+    /// </summary>
+    protected virtual string GetModelName(GenerateOptions? options)
+    {
+        // Check for model in options metadata
+        if (options?.AdditionalBodyParams?.TryGetValue("model", out var modelObj) == true &&
+            modelObj is string modelStr)
+        {
+            return modelStr;
+        }
+
+        // Default to Claude 3.5 Sonnet
+        return "claude-3-5-sonnet-20241022";
+    }
+
+    /// <summary>
+    /// Apply generation options to Anthropic request.
+    /// </summary>
+    protected virtual AnthropicRequest ApplyOptions(AnthropicRequest request, GenerateOptions? options)
+    {
+        if (options == null)
+        {
+            return request;
+        }
+
+        // Temperature
+        if (options.Temperature.HasValue)
+        {
+            request = request with { Temperature = options.Temperature.Value };
+        }
+
+        // Top P
+        if (options.TopP.HasValue)
+        {
+            request = request with { TopP = options.TopP.Value };
+        }
+
+        // Top K
+        if (options.TopK.HasValue)
+        {
+            request = request with { TopK = options.TopK.Value };
+        }
+
+        // Max tokens (already set in Format, but allow override)
+        if (options.MaxTokens.HasValue)
+        {
+            request = request with { MaxTokens = options.MaxTokens.Value };
+        }
+
+        // Stop sequences
+        if (options.Stop?.Count > 0)
+        {
+            request = request with { StopSequences = options.Stop };
+        }
+
+        // Apply tools if specified
+        if (options.AdditionalBodyParams?.TryGetValue("tools", out var toolsObj) == true &&
+            toolsObj is List<ToolSchema> tools)
+        {
+            request = ApplyTools(request, tools, options);
+        }
+
+        // Apply tool choice if specified
+        if (options.AdditionalBodyParams?.TryGetValue("tool_choice", out var toolChoiceObj) == true &&
+            toolChoiceObj is ToolChoice toolChoice)
+        {
+            request = ApplyToolChoice(request, toolChoice);
+        }
+
+        // Apply thinking config if specified (for Claude 3.7 Sonnet)
+        if (options.AdditionalBodyParams?.TryGetValue("thinking", out var thinkingObj) == true &&
+            thinkingObj is ThinkingConfig thinking)
+        {
+            request = request with { Thinking = thinking };
+        }
+
+        return request;
+    }
+
+    /// <summary>
+    /// Apply tool schemas to request.
+    /// </summary>
+    protected virtual AnthropicRequest ApplyTools(AnthropicRequest request, List<ToolSchema> tools, GenerateOptions options)
+    {
+        if (tools == null || tools.Count == 0)
+        {
+            return request;
+        }
+
+        var anthropicTools = tools.Select(t => new AnthropicTool
+        {
+            Name = t.Name,
+            Description = t.Description ?? $"Tool: {t.Name}",
+            InputSchema = t.Parameters ?? new Dictionary<string, object>()
+        }).ToList();
+
+        return request with { Tools = anthropicTools };
+    }
+
+    /// <summary>
+    /// Apply tool choice to request.
+    /// </summary>
+    protected virtual AnthropicRequest ApplyToolChoice(AnthropicRequest request, ToolChoice toolChoice)
+    {
+        AnthropicToolChoice anthropicToolChoice;
+
+        switch (toolChoice.Type)
+        {
+            case ToolChoiceType.Auto:
+                anthropicToolChoice = new AnthropicToolChoice { Type = AnthropicToolChoiceType.Auto };
+                break;
+            case ToolChoiceType.None:
+                // Anthropic doesn't have None, use Any as closest equivalent
+                anthropicToolChoice = new AnthropicToolChoice { Type = AnthropicToolChoiceType.Any };
+                break;
+            case ToolChoiceType.Required:
+                // Anthropic doesn't have Required, use Any which forces tool use
+                anthropicToolChoice = new AnthropicToolChoice { Type = AnthropicToolChoiceType.Any };
+                break;
+            case ToolChoiceType.Specific:
+                anthropicToolChoice = new AnthropicToolChoice
+                {
+                    Type = AnthropicToolChoiceType.Tool,
+                    Name = toolChoice.ToolName
+                };
+                break;
+            default:
+                return request;
+        }
+
+        return request with { ToolChoice = anthropicToolChoice };
+    }
+}

--- a/src/AgentScope.Core/Formatter/Anthropic/AnthropicChatFormatter.cs
+++ b/src/AgentScope.Core/Formatter/Anthropic/AnthropicChatFormatter.cs
@@ -1,0 +1,164 @@
+// Copyright 2024-2026 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using AgentScope.Core.Formatter.Anthropic.Dto;
+using AgentScope.Core.Message;
+using AgentScope.Core.Model;
+
+namespace AgentScope.Core.Formatter.Anthropic;
+
+/// <summary>
+/// Formatter for Anthropic Messages API.
+/// Converts between AgentScope Msg objects and Anthropic SDK types.
+/// Anthropic Chat 格式化器
+/// 
+/// Important: Anthropic API has special requirements:
+/// - Only the first message can be a system message (handled via system parameter)
+/// - Tool results must be in separate user messages
+/// - Supports thinking blocks natively (extended thinking feature)
+/// 
+/// Java参考: io.agentscope.core.formatter.anthropic.AnthropicChatFormatter
+/// </summary>
+public class AnthropicChatFormatter : AnthropicBaseFormatter, 
+    IFormatter<AnthropicRequest, AnthropicResponse, GenerateOptions>
+{
+    private readonly string _modelName;
+
+    /// <summary>
+    /// Create a new AnthropicChatFormatter with default model.
+    /// </summary>
+    public AnthropicChatFormatter() : this("claude-3-5-sonnet-20241022")
+    {
+    }
+
+    /// <summary>
+    /// Create a new AnthropicChatFormatter with specified model.
+    /// </summary>
+    /// <param name="modelName">Model name (e.g., "claude-3-opus-20240229", "claude-3-5-sonnet-20241022")</param>
+    public AnthropicChatFormatter(string modelName)
+    {
+        _modelName = modelName ?? throw new ArgumentNullException(nameof(modelName));
+    }
+
+    /// <summary>
+    /// Format messages to Anthropic request.
+    /// </summary>
+    List<AnthropicRequest> IFormatter<AnthropicRequest, AnthropicResponse, GenerateOptions>.Format(List<Msg> messages)
+    {
+        var request = Format(messages);
+        return new List<AnthropicRequest> { request };
+    }
+
+    /// <summary>
+    /// Parse Anthropic response to ModelResponse.
+    /// </summary>
+    ModelResponse IFormatter<AnthropicRequest, AnthropicResponse, GenerateOptions>.ParseResponse(
+        AnthropicResponse response, DateTime startTime)
+    {
+        return Parse(response, startTime);
+    }
+
+    /// <summary>
+    /// Apply generation options.
+    /// </summary>
+    void IFormatter<AnthropicRequest, AnthropicResponse, GenerateOptions>.ApplyOptions(
+        GenerateOptions paramsBuilder, GenerateOptions? options, GenerateOptions? defaultOptions)
+    {
+        // Merge options: defaultOptions first, then options override
+        if (defaultOptions != null)
+        {
+            MergeOptions(paramsBuilder, defaultOptions);
+        }
+        if (options != null)
+        {
+            MergeOptions(paramsBuilder, options);
+        }
+    }
+
+    /// <summary>
+    /// Apply tools to options.
+    /// </summary>
+    void IFormatter<AnthropicRequest, AnthropicResponse, GenerateOptions>.ApplyTools(
+        GenerateOptions paramsBuilder, List<ToolSchema>? tools)
+    {
+        if (tools != null && tools.Count > 0)
+        {
+            paramsBuilder.AdditionalBodyParams ??= new Dictionary<string, object>();
+            paramsBuilder.AdditionalBodyParams["tools"] = tools;
+        }
+    }
+
+    /// <summary>
+    /// Apply tools with provider compatibility.
+    /// </summary>
+    void IFormatter<AnthropicRequest, AnthropicResponse, GenerateOptions>.ApplyTools(
+        GenerateOptions paramsBuilder, List<ToolSchema>? tools, string? baseUrl, string? modelName)
+    {
+        // Delegate to the 2-parameter implementation
+        ((IFormatter<AnthropicRequest, AnthropicResponse, GenerateOptions>)this).ApplyTools(paramsBuilder, tools);
+    }
+
+    /// <summary>
+    /// Get model name.
+    /// </summary>
+    protected override string GetModelName(GenerateOptions? options)
+    {
+        // Check for model in options first
+        if (options?.AdditionalBodyParams?.TryGetValue("model", out var modelObj) == true &&
+            modelObj is string modelStr)
+        {
+            return modelStr;
+        }
+
+        return _modelName;
+    }
+
+    /// <summary>
+    /// Merge source options into target.
+    /// </summary>
+    private void MergeOptions(GenerateOptions target, GenerateOptions source)
+    {
+        if (source.Temperature.HasValue)
+            target.Temperature = source.Temperature;
+        if (source.MaxTokens.HasValue)
+            target.MaxTokens = source.MaxTokens;
+        if (source.TopP.HasValue)
+            target.TopP = source.TopP;
+        if (source.TopK.HasValue)
+            target.TopK = source.TopK;
+        if (source.FrequencyPenalty.HasValue)
+            target.FrequencyPenalty = source.FrequencyPenalty;
+        if (source.PresencePenalty.HasValue)
+            target.PresencePenalty = source.PresencePenalty;
+        if (source.Seed.HasValue)
+            target.Seed = source.Seed;
+        if (source.ResponseFormat != null)
+            target.ResponseFormat = source.ResponseFormat;
+        if (source.Stop?.Count > 0)
+        {
+            target.Stop ??= new List<string>();
+            target.Stop.AddRange(source.Stop);
+        }
+        if (source.AdditionalBodyParams?.Count > 0)
+        {
+            target.AdditionalBodyParams ??= new Dictionary<string, object>();
+            foreach (var kvp in source.AdditionalBodyParams)
+            {
+                target.AdditionalBodyParams[kvp.Key] = kvp.Value;
+            }
+        }
+    }
+}

--- a/src/AgentScope.Core/Formatter/Anthropic/AnthropicMessageConverter.cs
+++ b/src/AgentScope.Core/Formatter/Anthropic/AnthropicMessageConverter.cs
@@ -1,0 +1,288 @@
+// Copyright 2024-2026 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AgentScope.Core.Formatter.Anthropic.Dto;
+using AgentScope.Core.Message;
+
+namespace AgentScope.Core.Formatter.Anthropic;
+
+/// <summary>
+/// Converts AgentScope Msg objects to Anthropic SDK MessageParam types.
+/// Anthropic 消息转换器
+/// 
+/// Java参考: io.agentscope.core.formatter.anthropic.AnthropicMessageConverter
+/// </summary>
+public static class AnthropicMessageConverter
+{
+    /// <summary>
+    /// Convert list of Msg to list of Anthropic Message.
+    /// 将 AgentScope 消息列表转换为 Anthropic 消息列表
+    /// 
+    /// Important: Anthropic API has special requirements:
+    /// - Only the first message can be a system message (handled via system parameter)
+    /// - Tool results must be in separate user messages
+    /// </summary>
+    /// <param name="messages">AgentScope messages</param>
+    /// <returns>Anthropic messages</returns>
+    public static List<AnthropicMessage> Convert(List<Msg> messages)
+    {
+        var result = new List<AnthropicMessage>();
+
+        for (int i = 0; i < messages.Count; i++)
+        {
+            var msg = messages[i];
+            bool isFirstMessage = (i == 0);
+
+            // Check if this is a tool message (metadata contains tool_call_id)
+            if (IsToolResultMessage(msg))
+            {
+                // Tool results are handled separately as user messages
+                var toolResultMsg = ConvertToolResultMessage(msg);
+                if (toolResultMsg != null)
+                {
+                    result.Add(toolResultMsg);
+                }
+            }
+            else
+            {
+                var anthropicMsg = ConvertMessage(msg, isFirstMessage);
+                if (anthropicMsg != null)
+                {
+                    result.Add(anthropicMsg);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Extract system message content if present in the first message.
+    /// 从第一条消息中提取系统消息内容
+    /// 
+    /// In Anthropic API, system messages are passed via a separate 'system' parameter,
+    /// not as part of the messages list.
+    /// </summary>
+    /// <param name="messages">All messages including potential system message</param>
+    /// <returns>System message content or null</returns>
+    public static List<AnthropicSystemMessage>? ExtractSystemMessage(List<Msg> messages)
+    {
+        if (messages.Count == 0)
+        {
+            return null;
+        }
+
+        var first = messages[0];
+        if (first.Role == "system")
+        {
+            var text = first.GetTextContent();
+            if (!string.IsNullOrEmpty(text))
+            {
+                return new List<AnthropicSystemMessage>
+                {
+                    new AnthropicSystemMessage { Text = text }
+                };
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Convert a single AgentScope message to Anthropic message.
+    /// </summary>
+    private static AnthropicMessage? ConvertMessage(Msg msg, bool isFirstMessage)
+    {
+        var role = ConvertRole(msg.Role, isFirstMessage);
+        var contentBlocks = new List<AnthropicContentBlock>();
+
+        // Handle text content
+        var textContent = msg.GetTextContent();
+        if (!string.IsNullOrEmpty(textContent))
+        {
+            contentBlocks.Add(new Dto.TextBlock { Text = textContent });
+        }
+
+        // Handle tool calls (from metadata)
+        if (msg.Metadata?.TryGetValue("tool_calls", out var toolCalls) == true && toolCalls is List<object> calls)
+        {
+            foreach (var call in calls)
+            {
+                if (call is Dictionary<string, object> toolCall)
+                {
+                    var toolUseBlock = ConvertToolCall(toolCall);
+                    if (toolUseBlock != null)
+                    {
+                        contentBlocks.Add(toolUseBlock);
+                    }
+                }
+            }
+        }
+
+        // Handle images (from metadata)
+        if (msg.Metadata?.TryGetValue("image_urls", out var imageUrls) == true && imageUrls is List<string> urls)
+        {
+            foreach (var url in urls)
+            {
+                var imageBlock = ConvertImage(url);
+                if (imageBlock != null)
+                {
+                    contentBlocks.Add(imageBlock);
+                }
+            }
+        }
+
+        if (contentBlocks.Count == 0)
+        {
+            return null;
+        }
+
+        return new AnthropicMessage
+        {
+            Role = role,
+            Content = contentBlocks
+        };
+    }
+
+    /// <summary>
+    /// Check if a message is a tool result message.
+    /// </summary>
+    private static bool IsToolResultMessage(Msg msg)
+    {
+        return msg.Role == "tool" || 
+               (msg.Metadata?.ContainsKey("tool_call_id") == true);
+    }
+
+    /// <summary>
+    /// Convert a tool result message to Anthropic user message.
+    /// </summary>
+    private static AnthropicMessage? ConvertToolResultMessage(Msg msg)
+    {
+        var toolCallId = msg.Metadata?["tool_call_id"] as string;
+        if (string.IsNullOrEmpty(toolCallId))
+        {
+            return null;
+        }
+
+        var content = msg.GetTextContent() ?? "";
+        var isError = msg.Metadata?.TryGetValue("is_error", out var errorVal) == true && 
+                      errorVal is true;
+
+        var toolResultContent = new List<Dto.ToolResultContent>
+        {
+            new Dto.ToolResultContent
+            {
+                Type = "text",
+                Text = content
+            }
+        };
+
+        var toolResultBlock = new Dto.ToolResultBlock
+        {
+            ToolUseId = toolCallId,
+            Content = toolResultContent,
+            IsError = isError ? true : null
+        };
+
+        return new AnthropicMessage
+        {
+            Role = AnthropicRole.User,
+            Content = new List<AnthropicContentBlock> { toolResultBlock }
+        };
+    }
+
+    /// <summary>
+    /// Convert a tool call from metadata to Anthropic ToolUseBlock.
+    /// </summary>
+    private static Dto.ToolUseBlock? ConvertToolCall(Dictionary<string, object> toolCall)
+    {
+        var id = toolCall.GetValueOrDefault("id") as string;
+        var name = toolCall.GetValueOrDefault("name") as string ?? 
+                   toolCall.GetValueOrDefault("function")?.ToString();
+        var arguments = toolCall.GetValueOrDefault("arguments") as Dictionary<string, object> ??
+                        new Dictionary<string, object>();
+
+        if (string.IsNullOrEmpty(id) || string.IsNullOrEmpty(name))
+        {
+            return null;
+        }
+
+        return new Dto.ToolUseBlock
+        {
+            Id = id,
+            Name = name,
+            Input = arguments
+        };
+    }
+
+    /// <summary>
+    /// Convert an image URL to Anthropic ImageBlock.
+    /// </summary>
+    private static Dto.ImageBlock? ConvertImage(string url)
+    {
+        try
+        {
+            // Handle base64 data URLs
+            if (url.StartsWith("data:image/"))
+            {
+                var parts = url.Split(',');
+                if (parts.Length == 2)
+                {
+                    var mediaType = parts[0].Split(';')[0].Replace("data:", "");
+                    var base64Data = parts[1];
+
+                    return new Dto.ImageBlock
+                    {
+                        Source = new Dto.ImageSource
+                        {
+                            Type = "base64",
+                            MediaType = mediaType,
+                            Data = base64Data
+                        }
+                    };
+                }
+            }
+
+            // For HTTP URLs, we would need to download and convert to base64
+            // For now, return null as this requires async I/O
+            return null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Convert AgentScope role to Anthropic role.
+    /// 
+    /// Important: Anthropic only allows the first message to be system.
+    /// Non-first system messages are converted to user.
+    /// Tool results are always user messages.
+    /// </summary>
+    private static AnthropicRole ConvertRole(string role, bool isFirstMessage)
+    {
+        return role.ToLower() switch
+        {
+            "system" => AnthropicRole.User, // Anthropic uses user for system messages in the messages list
+            "user" => AnthropicRole.User,
+            "assistant" => AnthropicRole.Assistant,
+            "tool" => AnthropicRole.User, // Tool results are user messages
+            _ => AnthropicRole.User
+        };
+    }
+}

--- a/src/AgentScope.Core/Formatter/Anthropic/AnthropicResponseParser.cs
+++ b/src/AgentScope.Core/Formatter/Anthropic/AnthropicResponseParser.cs
@@ -1,0 +1,245 @@
+// Copyright 2024-2026 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using AgentScope.Core.Formatter.Anthropic.Dto;
+using AgentScope.Core.Message;
+using AgentScope.Core.Model;
+
+namespace AgentScope.Core.Formatter.Anthropic;
+
+/// <summary>
+/// Parses Anthropic API responses into AgentScope ChatResponse objects.
+/// Anthropic 响应解析器
+/// 
+/// Java参考: io.agentscope.core.formatter.anthropic.AnthropicResponseParser
+/// </summary>
+public static class AnthropicResponseParser
+{
+    /// <summary>
+    /// Parse non-streaming Anthropic response to ChatResponse.
+    /// </summary>
+    /// <param name="response">Anthropic response</param>
+    /// <param name="startTime">Request start time</param>
+    /// <returns>AgentScope ChatResponse</returns>
+    public static ChatResponse ParseMessage(AnthropicResponse response, DateTime startTime)
+    {
+        var contentBlocks = new List<ContentBlock>();
+        var toolCalls = new List<ToolCallInfo>();
+        string? thinkingContent = null;
+
+        // Process content blocks
+        foreach (var block in response.Content)
+        {
+            switch (block)
+            {
+                case Dto.TextBlock textBlock:
+                    contentBlocks.Add(new Message.TextBlock { Text = textBlock.Text });
+                    break;
+
+                case Dto.ThinkingBlock thinkingBlock:
+                    thinkingContent = thinkingContent != null 
+                        ? thinkingContent + "\n" + thinkingBlock.Thinking 
+                        : thinkingBlock.Thinking;
+                    break;
+
+                case Dto.ToolUseBlock toolUse:
+                    toolCalls.Add(new ToolCallInfo
+                    {
+                        Id = toolUse.Id,
+                        Name = toolUse.Name,
+                        Arguments = JsonSerializer.Serialize(toolUse.Input),
+                        Type = "function"
+                    });
+                    break;
+            }
+        }
+
+        // Build response text from content blocks
+        var responseText = string.Join("\n", contentBlocks.OfType<Message.TextBlock>().Select(t => t.Text));
+
+        // Build usage info
+        var usage = new ChatUsage
+        {
+            InputTokens = response.Usage.InputTokens,
+            OutputTokens = response.Usage.OutputTokens,
+            TotalTokens = response.Usage.InputTokens + response.Usage.OutputTokens,
+            TimeSeconds = (DateTime.UtcNow - startTime).TotalSeconds
+        };
+
+        var chatResponse = new ChatResponse
+        {
+            Id = response.Id,
+            Text = responseText,  // Set both Text (base class) and Content
+            Content = responseText,
+            ToolCalls = toolCalls.Count > 0 ? toolCalls : null,
+            Usage = usage,
+            Model = response.Model,
+            StopReason = response.StopReason
+        };
+
+        // Add thinking content to metadata if present
+        if (!string.IsNullOrEmpty(thinkingContent))
+        {
+            chatResponse.Metadata ??= new Dictionary<string, object>();
+            chatResponse.Metadata["thinking"] = thinkingContent;
+        }
+
+        return chatResponse;
+    }
+
+    /// <summary>
+    /// Parse streaming Anthropic event to partial ChatResponse.
+    /// </summary>
+    /// <param name="streamEvent">Stream event</param>
+    /// <param name="messageId">Current message ID</param>
+    /// <param name="accumulatedToolInput">Accumulated tool input for streaming tool calls</param>
+    /// <returns>Partial ChatResponse or null</returns>
+    public static ChatResponse? ParseStreamEvent(
+        AnthropicStreamEvent streamEvent, 
+        ref string? messageId,
+        ref Dictionary<string, StringBuilder> accumulatedToolInput)
+    {
+        // Message start - capture ID
+        if (streamEvent.EventType == "message_start" && streamEvent.Message != null)
+        {
+            messageId = streamEvent.Message.Id;
+            return null;
+        }
+
+        // Content block delta - text or tool input
+        if (streamEvent.EventType == "content_block_delta" && streamEvent.Delta != null)
+        {
+            // Text delta
+            if (!string.IsNullOrEmpty(streamEvent.Delta.Text))
+            {
+                return new ChatResponse
+                {
+                    Id = messageId ?? "",
+                    Content = streamEvent.Delta.Text,
+                    ToolCalls = null,
+                    Usage = null
+                };
+            }
+
+            // Thinking delta
+            if (!string.IsNullOrEmpty(streamEvent.Delta.Thinking))
+            {
+                return new ChatResponse
+                {
+                    Id = messageId ?? "",
+                    Content = "",
+                    Metadata = new Dictionary<string, object> { ["thinking"] = streamEvent.Delta.Thinking },
+                    Usage = null
+                };
+            }
+
+            // Tool input delta (streaming JSON)
+            if (!string.IsNullOrEmpty(streamEvent.Delta.PartialJson))
+            {
+                // Accumulate partial JSON for tool calls
+                // The actual tool call will be assembled when content_block_stop event fires
+                return null;
+            }
+        }
+
+        // Content block start - tool use start
+        if (streamEvent.EventType == "content_block_start" && streamEvent.ContentBlock is Dto.ToolUseBlock toolUse)
+        {
+            // Initialize accumulation for this tool call
+            accumulatedToolInput[toolUse.Id] = new StringBuilder();
+            
+            return new ChatResponse
+            {
+                Id = messageId ?? "",
+                Content = "",
+                ToolCalls = new List<ToolCallInfo>
+                {
+                    new ToolCallInfo
+                    {
+                        Id = toolUse.Id,
+                        Name = toolUse.Name,
+                        Arguments = "", // Will be filled on content_block_stop
+                        Type = "function"
+                    }
+                },
+                Usage = null
+            };
+        }
+
+        // Message delta - usage info
+        if (streamEvent.EventType == "message_delta" && streamEvent.Usage != null)
+        {
+            return new ChatResponse
+            {
+                Id = messageId ?? "",
+                Content = "",
+                Usage = new ChatUsage
+                {
+                    OutputTokens = streamEvent.Usage.OutputTokens
+                }
+            };
+        }
+
+        // Message stop - final event
+        if (streamEvent.EventType == "message_stop")
+        {
+            return new ChatResponse
+            {
+                Id = messageId ?? "",
+                Content = "",
+                IsComplete = true
+            };
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Parse JSON input for tool calls.
+    /// </summary>
+    private static Dictionary<string, object> ParseJsonInput(string json, string toolName)
+    {
+        if (string.IsNullOrEmpty(json))
+        {
+            return new Dictionary<string, object>();
+        }
+
+        try
+        {
+            var result = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
+            return result ?? new Dictionary<string, object>();
+        }
+        catch (System.Exception ex)
+        {
+            // Log warning but don't fail
+            Console.WriteLine($"Warning: Failed to parse tool input JSON for tool {toolName}: {ex.Message}");
+            return new Dictionary<string, object>();
+        }
+    }
+
+    /// <summary>
+    /// StringBuilder class for accumulating tool input in streams.
+    /// </summary>
+    public class StringBuilder
+    {
+        private readonly System.Text.StringBuilder _sb = new();
+
+        public void Append(string text) => _sb.Append(text);
+        public override string ToString() => _sb.ToString();
+    }
+}

--- a/src/AgentScope.Core/Formatter/Anthropic/Dto/AnthropicContentBlock.cs
+++ b/src/AgentScope.Core/Formatter/Anthropic/Dto/AnthropicContentBlock.cs
@@ -1,0 +1,158 @@
+// Copyright 2024-2026 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace AgentScope.Core.Formatter.Anthropic.Dto;
+
+/// <summary>
+/// Anthropic 内容块基类
+/// Anthropic content block base class
+/// </summary>
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
+[JsonDerivedType(typeof(TextBlock), typeDiscriminator: "text")]
+[JsonDerivedType(typeof(ImageBlock), typeDiscriminator: "image")]
+[JsonDerivedType(typeof(ToolUseBlock), typeDiscriminator: "tool_use")]
+[JsonDerivedType(typeof(ToolResultBlock), typeDiscriminator: "tool_result")]
+[JsonDerivedType(typeof(ThinkingBlock), typeDiscriminator: "thinking")]
+public abstract record AnthropicContentBlock
+{
+    [JsonPropertyName("type")]
+    public abstract string Type { get; }
+}
+
+/// <summary>
+/// 文本内容块
+/// Text content block
+/// </summary>
+public record TextBlock : AnthropicContentBlock
+{
+    [JsonPropertyName("type")]
+    public override string Type => "text";
+
+    [JsonPropertyName("text")]
+    public required string Text { get; init; }
+}
+
+/// <summary>
+/// 图片来源
+/// Image source
+/// </summary>
+public record ImageSource
+{
+    [JsonPropertyName("type")]
+    public required string Type { get; init; }  // "base64"
+
+    [JsonPropertyName("media_type")]
+    public required string MediaType { get; init; }  // "image/png", "image/jpeg", etc.
+
+    [JsonPropertyName("data")]
+    public required string Data { get; init; }  // base64 string
+}
+
+/// <summary>
+/// 图片内容块
+/// Image content block
+/// </summary>
+public record ImageBlock : AnthropicContentBlock
+{
+    [JsonPropertyName("type")]
+    public override string Type => "image";
+
+    [JsonPropertyName("source")]
+    public required ImageSource Source { get; init; }
+}
+
+/// <summary>
+/// 工具使用块
+/// Tool use block (represents a tool call from the assistant)
+/// </summary>
+public record ToolUseBlock : AnthropicContentBlock
+{
+    [JsonPropertyName("type")]
+    public override string Type => "tool_use";
+
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("input")]
+    public required Dictionary<string, object> Input { get; init; }
+}
+
+/// <summary>
+/// 工具结果内容块
+/// Tool result content block
+/// </summary>
+public record ToolResultContent
+{
+    [JsonPropertyName("type")]
+    public required string Type { get; init; }  // "text" or "image"
+
+    [JsonPropertyName("text")]
+    public string? Text { get; init; }
+
+    [JsonPropertyName("source")]
+    public ImageSource? Source { get; init; }
+}
+
+/// <summary>
+/// 工具结果块
+/// Tool result block (represents the result of a tool execution)
+/// </summary>
+public record ToolResultBlock : AnthropicContentBlock
+{
+    [JsonPropertyName("type")]
+    public override string Type => "tool_result";
+
+    [JsonPropertyName("tool_use_id")]
+    public required string ToolUseId { get; init; }
+
+    [JsonPropertyName("content")]
+    public required List<ToolResultContent> Content { get; init; }
+
+    [JsonPropertyName("is_error")]
+    public bool? IsError { get; init; }
+}
+
+/// <summary>
+/// 思考内容块（Claude 3.7 Sonnet 特有的 extended thinking 功能）
+/// Thinking block (Claude 3.7 Sonnet extended thinking feature)
+/// </summary>
+public record ThinkingBlock : AnthropicContentBlock
+{
+    [JsonPropertyName("type")]
+    public override string Type => "thinking";
+
+    [JsonPropertyName("thinking")]
+    public required string Thinking { get; init; }
+
+    [JsonPropertyName("signature")]
+    public string? Signature { get; init; }
+}
+
+/// <summary>
+/// Redacted thinking block (for sensitive content)
+/// </summary>
+public record RedactedThinkingBlock : AnthropicContentBlock
+{
+    [JsonPropertyName("type")]
+    public override string Type => "redacted_thinking";
+
+    [JsonPropertyName("data")]
+    public required string Data { get; init; }
+}

--- a/src/AgentScope.Core/Formatter/Anthropic/Dto/AnthropicMessage.cs
+++ b/src/AgentScope.Core/Formatter/Anthropic/Dto/AnthropicMessage.cs
@@ -1,0 +1,69 @@
+// Copyright 2024-2026 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace AgentScope.Core.Formatter.Anthropic.Dto;
+
+/// <summary>
+/// Anthropic 消息角色
+/// Anthropic message role
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum AnthropicRole
+{
+    [JsonStringEnumMemberName("user")]
+    User,
+
+    [JsonStringEnumMemberName("assistant")]
+    Assistant
+}
+
+/// <summary>
+/// Anthropic 消息
+/// Anthropic message
+/// </summary>
+public record AnthropicMessage
+{
+    [JsonPropertyName("role")]
+    public required AnthropicRole Role { get; init; }
+
+    [JsonPropertyName("content")]
+    public required List<AnthropicContentBlock> Content { get; init; }
+
+    public AnthropicMessage()
+    {
+        Content = new List<AnthropicContentBlock>();
+    }
+
+    public AnthropicMessage(AnthropicRole role, List<AnthropicContentBlock> content)
+    {
+        Role = role;
+        Content = content;
+    }
+}
+
+/// <summary>
+/// 系统消息（Anthropic API 使用单独的 system 参数）
+/// System message (Anthropic API uses separate system parameter)
+/// </summary>
+public record AnthropicSystemMessage
+{
+    [JsonPropertyName("type")]
+    public string Type => "text";
+
+    [JsonPropertyName("text")]
+    public required string Text { get; init; }
+}

--- a/src/AgentScope.Core/Formatter/Anthropic/Dto/AnthropicRequest.cs
+++ b/src/AgentScope.Core/Formatter/Anthropic/Dto/AnthropicRequest.cs
@@ -1,0 +1,150 @@
+// Copyright 2024-2026 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace AgentScope.Core.Formatter.Anthropic.Dto;
+
+/// <summary>
+/// Anthropic Messages API 请求
+/// Anthropic Messages API request
+/// 
+/// Java参考: com.anthropic.models.messages.MessageCreateParams
+/// </summary>
+public record AnthropicRequest
+{
+    /// <summary>
+    /// 模型名称 / Model name (e.g., "claude-3-opus-20240229", "claude-3-5-sonnet-20241022")
+    /// </summary>
+    [JsonPropertyName("model")]
+    public required string Model { get; init; }
+
+    /// <summary>
+    /// 消息列表 / List of messages
+    /// </summary>
+    [JsonPropertyName("messages")]
+    public required List<AnthropicMessage> Messages { get; init; }
+
+    /// <summary>
+    /// 系统提示（Anthropic 使用单独的 system 参数）
+    /// System prompt (Anthropic uses separate system parameter, not as a message)
+    /// </summary>
+    [JsonPropertyName("system")]
+    public List<AnthropicSystemMessage>? System { get; init; }
+
+    /// <summary>
+    /// 最大生成 token 数（Anthropic 要求必填）
+    /// Maximum number of tokens to generate (required for Anthropic)
+    /// </summary>
+    [JsonPropertyName("max_tokens")]
+    public required int MaxTokens { get; init; }
+
+    /// <summary>
+    /// 温度参数 (0.0 - 1.0)
+    /// Temperature parameter (0.0 - 1.0)
+    /// </summary>
+    [JsonPropertyName("temperature")]
+    public double? Temperature { get; init; }
+
+    /// <summary>
+    /// Top P 参数
+    /// Top P parameter
+    /// </summary>
+    [JsonPropertyName("top_p")]
+    public double? TopP { get; init; }
+
+    /// <summary>
+    /// Top K 参数
+    /// Top K parameter
+    /// </summary>
+    [JsonPropertyName("top_k")]
+    public int? TopK { get; init; }
+
+    /// <summary>
+    /// 停止序列
+    /// Stop sequences
+    /// </summary>
+    [JsonPropertyName("stop_sequences")]
+    public List<string>? StopSequences { get; init; }
+
+    /// <summary>
+    /// 是否流式输出
+    /// Whether to stream the response
+    /// </summary>
+    [JsonPropertyName("stream")]
+    public bool Stream { get; init; }
+
+    /// <summary>
+    /// 工具列表
+    /// List of tools available to the model
+    /// </summary>
+    [JsonPropertyName("tools")]
+    public List<AnthropicTool>? Tools { get; init; }
+
+    /// <summary>
+    /// 工具选择配置
+    /// Tool choice configuration
+    /// </summary>
+    [JsonPropertyName("tool_choice")]
+    public AnthropicToolChoice? ToolChoice { get; init; }
+
+    /// <summary>
+    /// 思考配置（Claude 3.7 Sonnet extended thinking）
+    /// Thinking configuration (Claude 3.7 Sonnet extended thinking)
+    /// </summary>
+    [JsonPropertyName("thinking")]
+    public ThinkingConfig? Thinking { get; init; }
+
+    /// <summary>
+    /// 元数据
+    /// Metadata for the request
+    /// </summary>
+    [JsonPropertyName("metadata")]
+    public AnthropicMetadata? Metadata { get; init; }
+}
+
+/// <summary>
+/// 思考配置
+/// Thinking configuration for Claude 3.7 Sonnet
+/// </summary>
+public record ThinkingConfig
+{
+    /// <summary>
+    /// 思考类型 / Thinking type ("enabled")
+    /// </summary>
+    [JsonPropertyName("type")]
+    public required string Type { get; init; }
+
+    /// <summary>
+    /// 预算 tokens（用于思考的最大 token 数）
+    /// Budget tokens (maximum tokens to use for thinking)
+    /// </summary>
+    [JsonPropertyName("budget_tokens")]
+    public required int BudgetTokens { get; init; }
+}
+
+/// <summary>
+/// 请求元数据
+/// Request metadata
+/// </summary>
+public record AnthropicMetadata
+{
+    /// <summary>
+    /// 用户标识
+    /// User identifier
+    /// </summary>
+    [JsonPropertyName("user_id")]
+    public string? UserId { get; init; }
+}

--- a/src/AgentScope.Core/Formatter/Anthropic/Dto/AnthropicResponse.cs
+++ b/src/AgentScope.Core/Formatter/Anthropic/Dto/AnthropicResponse.cs
@@ -1,0 +1,162 @@
+// Copyright 2024-2026 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace AgentScope.Core.Formatter.Anthropic.Dto;
+
+/// <summary>
+/// Anthropic Messages API 响应
+/// Anthropic Messages API response
+/// 
+/// Java参考: com.anthropic.models.messages.Message
+/// </summary>
+public record AnthropicResponse
+{
+    /// <summary>
+    /// 响应 ID
+    /// Response ID
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// 类型（通常为 "message"）
+    /// Type (usually "message")
+    /// </summary>
+    [JsonPropertyName("type")]
+    public required string Type { get; init; }
+
+    /// <summary>
+    /// 角色（"assistant"）
+    /// Role ("assistant")
+    /// </summary>
+    [JsonPropertyName("role")]
+    public required AnthropicRole Role { get; init; }
+
+    /// <summary>
+    /// 内容块列表
+    /// List of content blocks
+    /// </summary>
+    [JsonPropertyName("content")]
+    public required List<AnthropicContentBlock> Content { get; init; }
+
+    /// <summary>
+    /// 模型名称
+    /// Model name
+    /// </summary>
+    [JsonPropertyName("model")]
+    public required string Model { get; init; }
+
+    /// <summary>
+    /// 停止原因
+    /// Stop reason: "end_turn", "max_tokens", "stop_sequence", "tool_use"
+    /// </summary>
+    [JsonPropertyName("stop_reason")]
+    public string? StopReason { get; init; }
+
+    /// <summary>
+    /// 停止序列
+    /// Stop sequence that caused the stop
+    /// </summary>
+    [JsonPropertyName("stop_sequence")]
+    public string? StopSequence { get; init; }
+
+    /// <summary>
+    /// Token 使用量
+    /// Token usage information
+    /// </summary>
+    [JsonPropertyName("usage")]
+    public required AnthropicUsage Usage { get; init; }
+}
+
+/// <summary>
+/// Token 使用量
+/// Token usage
+/// </summary>
+public record AnthropicUsage
+{
+    /// <summary>
+    /// 输入 token 数
+    /// Input tokens
+    /// </summary>
+    [JsonPropertyName("input_tokens")]
+    public required int InputTokens { get; init; }
+
+    /// <summary>
+    /// 输出 token 数
+    /// Output tokens
+    /// </summary>
+    [JsonPropertyName("output_tokens")]
+    public required int OutputTokens { get; init; }
+
+    /// <summary>
+    /// 缓存创建 token 数
+    /// Cache creation input tokens
+    /// </summary>
+    [JsonPropertyName("cache_creation_input_tokens")]
+    public int? CacheCreationInputTokens { get; init; }
+
+    /// <summary>
+    /// 缓存读取 token 数
+    /// Cache read input tokens
+    /// </summary>
+    [JsonPropertyName("cache_read_input_tokens")]
+    public int? CacheReadInputTokens { get; init; }
+}
+
+/// <summary>
+/// 流式响应事件（用于 SSE 流）
+/// Streaming response event (for SSE stream)
+/// </summary>
+public record AnthropicStreamEvent
+{
+    [JsonPropertyName("type")]
+    public required string EventType { get; init; }
+
+    [JsonPropertyName("message")]
+    public AnthropicResponse? Message { get; init; }
+
+    [JsonPropertyName("content_block")]
+    public AnthropicContentBlock? ContentBlock { get; init; }
+
+    [JsonPropertyName("delta")]
+    public AnthropicContentDelta? Delta { get; init; }
+
+    [JsonPropertyName("usage")]
+    public AnthropicUsage? Usage { get; init; }
+
+    [JsonPropertyName("index")]
+    public int? Index { get; init; }
+}
+
+/// <summary>
+/// 内容增量（流式响应）
+/// Content delta for streaming responses
+/// </summary>
+public record AnthropicContentDelta
+{
+    [JsonPropertyName("type")]
+    public string? Type { get; init; }
+
+    [JsonPropertyName("text")]
+    public string? Text { get; init; }
+
+    [JsonPropertyName("thinking")]
+    public string? Thinking { get; init; }
+
+    [JsonPropertyName("partial_json")]
+    public string? PartialJson { get; init; }
+}

--- a/src/AgentScope.Core/Formatter/Anthropic/Dto/AnthropicTool.cs
+++ b/src/AgentScope.Core/Formatter/Anthropic/Dto/AnthropicTool.cs
@@ -1,0 +1,74 @@
+// Copyright 2024-2026 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace AgentScope.Core.Formatter.Anthropic.Dto;
+
+/// <summary>
+/// Anthropic 工具定义
+/// Anthropic tool definition
+/// </summary>
+public record AnthropicTool
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+
+    [JsonPropertyName("input_schema")]
+    public required Dictionary<string, object> InputSchema { get; init; }
+}
+
+/// <summary>
+/// 工具选择类型
+/// Tool choice type
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum AnthropicToolChoiceType
+{
+    [JsonStringEnumMemberName("auto")]
+    Auto,
+
+    [JsonStringEnumMemberName("any")]
+    Any,
+
+    [JsonStringEnumMemberName("tool")]
+    Tool
+}
+
+/// <summary>
+/// 工具选择配置
+/// Tool choice configuration
+/// </summary>
+public record AnthropicToolChoice
+{
+    [JsonPropertyName("type")]
+    public required AnthropicToolChoiceType Type { get; init; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }  // Required when Type is Tool
+}
+
+/// <summary>
+/// 缓存控制（Prompt Caching）
+/// Cache control for prompt caching
+/// </summary>
+public record CacheControl
+{
+    [JsonPropertyName("type")]
+    public required string Type { get; init; }  // "ephemeral"
+}

--- a/src/AgentScope.Core/Formatter/IFormatter.cs
+++ b/src/AgentScope.Core/Formatter/IFormatter.cs
@@ -76,6 +76,33 @@ public interface IFormatter<TRequest, TResponse, TParams>
 }
 
 /// <summary>
+/// 工具选择类型
+/// Tool choice type
+/// </summary>
+public enum ToolChoiceType
+{
+    Auto,
+    None,
+    Required,
+    Specific
+}
+
+/// <summary>
+/// 工具选择配置
+/// Tool choice configuration
+/// </summary>
+public class ToolChoice
+{
+    public ToolChoiceType Type { get; set; }
+    public string? ToolName { get; set; }
+
+    public static ToolChoice Auto() => new() { Type = ToolChoiceType.Auto };
+    public static ToolChoice None() => new() { Type = ToolChoiceType.None };
+    public static ToolChoice Required() => new() { Type = ToolChoiceType.Required };
+    public static ToolChoice Specific(string toolName) => new() { Type = ToolChoiceType.Specific, ToolName = toolName };
+}
+
+/// <summary>
 /// 生成选项
 /// Generation options for LLM requests
 /// </summary>
@@ -90,6 +117,25 @@ public class GenerateOptions
     public List<string>? Stop { get; set; }
     public int? Seed { get; set; }
     public ResponseFormat? ResponseFormat { get; set; }
+    public ToolChoice? ToolChoice { get; set; }
+
+    /// <summary>
+    /// 额外的请求体参数（提供商特定）
+    /// Additional body parameters (provider-specific)
+    /// </summary>
+    public Dictionary<string, object>? AdditionalBodyParams { get; set; }
+
+    /// <summary>
+    /// 额外的请求头
+    /// Additional headers
+    /// </summary>
+    public Dictionary<string, string>? AdditionalHeaders { get; set; }
+
+    /// <summary>
+    /// 额外的查询参数
+    /// Additional query parameters
+    /// </summary>
+    public Dictionary<string, string>? AdditionalQueryParams { get; set; }
 }
 
 /// <summary>

--- a/src/AgentScope.Core/Message/ContentBlock.cs
+++ b/src/AgentScope.Core/Message/ContentBlock.cs
@@ -1,0 +1,86 @@
+// Copyright 2024-2026 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+
+namespace AgentScope.Core.Message;
+
+/// <summary>
+/// Content block base class for multimodal messages
+/// 内容块基类，用于多模态消息
+/// 
+/// Java参考: io.agentscope.core.message.ContentBlock
+/// </summary>
+public abstract record ContentBlock
+{
+    public abstract string Type { get; }
+}
+
+/// <summary>
+/// Text content block
+/// 文本内容块
+/// </summary>
+public record TextBlock : ContentBlock
+{
+    public override string Type => "text";
+    public required string Text { get; set; }
+}
+
+/// <summary>
+/// Image content block
+/// 图片内容块
+/// </summary>
+public record ImageBlock : ContentBlock
+{
+    public override string Type => "image";
+    public required string Url { get; set; }
+    public string? MimeType { get; set; }
+    public byte[]? Data { get; set; }
+}
+
+/// <summary>
+/// Tool use block (represents a tool call from the assistant)
+/// 工具使用块（表示助手的工具调用）
+/// </summary>
+public record ToolUseBlock : ContentBlock
+{
+    public override string Type => "tool_use";
+    public required string Id { get; set; }
+    public required string Name { get; set; }
+    public Dictionary<string, object>? Input { get; set; }
+    public string? Content { get; set; }
+}
+
+/// <summary>
+/// Tool result block (represents the result of a tool execution)
+/// 工具结果块（表示工具执行的结果）
+/// </summary>
+public record ToolResultBlock : ContentBlock
+{
+    public override string Type => "tool_result";
+    public required string Id { get; set; }
+    public object? Output { get; set; }
+    public bool IsError { get; set; }
+}
+
+/// <summary>
+/// Thinking block (for models with extended thinking capability)
+/// 思考块（用于具有扩展思考能力的模型）
+/// </summary>
+public record ThinkingBlock : ContentBlock
+{
+    public override string Type => "thinking";
+    public required string Thinking { get; set; }
+    public string? Signature { get; set; }
+}

--- a/src/AgentScope.Core/Model/ChatResponse.cs
+++ b/src/AgentScope.Core/Model/ChatResponse.cs
@@ -1,0 +1,115 @@
+// Copyright 2024-2026 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+
+namespace AgentScope.Core.Model;
+
+/// <summary>
+/// Chat response with detailed information
+/// 聊天响应详细信息
+/// 
+/// Java参考: io.agentscope.core.model.ChatResponse
+/// </summary>
+public class ChatResponse : ModelResponse
+{
+    /// <summary>
+    /// Response ID
+    /// </summary>
+    public string? Id { get; set; }
+
+    /// <summary>
+    /// Response content (text)
+    /// </summary>
+    public new string? Content { get; set; }
+
+    /// <summary>
+    /// Tool calls in the response
+    /// </summary>
+    public List<ToolCallInfo>? ToolCalls { get; set; }
+
+    /// <summary>
+    /// Token usage information
+    /// </summary>
+    public ChatUsage? Usage { get; set; }
+
+    /// <summary>
+    /// Model name used
+    /// </summary>
+    public string? Model { get; set; }
+
+    /// <summary>
+    /// Stop reason
+    /// </summary>
+    public string? StopReason { get; set; }
+
+    /// <summary>
+    /// Whether this is the final response in a stream
+    /// </summary>
+    public bool IsComplete { get; set; }
+}
+
+/// <summary>
+/// Tool call information
+/// 工具调用信息
+/// </summary>
+public class ToolCallInfo
+{
+    /// <summary>
+    /// Tool call ID
+    /// </summary>
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// Tool type (usually "function")
+    /// </summary>
+    public string? Type { get; set; }
+
+    /// <summary>
+    /// Tool/function name
+    /// </summary>
+    public required string Name { get; set; }
+
+    /// <summary>
+    /// Tool arguments as JSON string
+    /// </summary>
+    public string? Arguments { get; set; }
+}
+
+/// <summary>
+/// Token usage information
+/// Token 使用信息
+/// </summary>
+public class ChatUsage
+{
+    /// <summary>
+    /// Input tokens
+    /// </summary>
+    public int InputTokens { get; set; }
+
+    /// <summary>
+    /// Output tokens
+    /// </summary>
+    public int OutputTokens { get; set; }
+
+    /// <summary>
+    /// Total tokens
+    /// </summary>
+    public int TotalTokens { get; set; }
+
+    /// <summary>
+    /// Response time in seconds
+    /// </summary>
+    public double TimeSeconds { get; set; }
+}

--- a/tests/AgentScope.Core.Tests/Formatter/Anthropic/AnthropicFormatterTests.cs
+++ b/tests/AgentScope.Core.Tests/Formatter/Anthropic/AnthropicFormatterTests.cs
@@ -1,0 +1,392 @@
+// Copyright 2024-2026 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AgentScope.Core.Formatter;
+using AgentScope.Core.Formatter.Anthropic;
+using Dto = AgentScope.Core.Formatter.Anthropic.Dto;
+using AgentScope.Core.Message;
+using Xunit;
+
+// Alias for DTO types
+using AnthropicRole = AgentScope.Core.Formatter.Anthropic.Dto.AnthropicRole;
+using AnthropicResponse = AgentScope.Core.Formatter.Anthropic.Dto.AnthropicResponse;
+using AnthropicRequest = AgentScope.Core.Formatter.Anthropic.Dto.AnthropicRequest;
+using AnthropicContentBlock = AgentScope.Core.Formatter.Anthropic.Dto.AnthropicContentBlock;
+using AnthropicUsage = AgentScope.Core.Formatter.Anthropic.Dto.AnthropicUsage;
+
+namespace AgentScope.Core.Tests.Formatter.Anthropic;
+
+/// <summary>
+/// Tests for Anthropic Formatter
+/// Anthropic 格式化器测试
+/// </summary>
+public class AnthropicFormatterTests
+{
+    #region Format Tests
+
+    [Fact]
+    public void Format_SingleUserMessage_CreatesValidRequest()
+    {
+        // Arrange
+        var formatter = new AnthropicChatFormatter("claude-3-5-sonnet-20241022");
+        var messages = new List<Msg>
+        {
+            Msg.Builder().Role("user").TextContent("Hello, Claude!").Build()
+        };
+
+        // Act
+        var request = formatter.Format(messages);
+
+        // Assert
+        Assert.NotNull(request);
+        Assert.Equal("claude-3-5-sonnet-20241022", request.Model);
+        Assert.Single(request.Messages);
+        Assert.Equal(AnthropicRole.User, request.Messages[0].Role);
+        Assert.Equal(4096, request.MaxTokens); // Default
+    }
+
+    [Fact]
+    public void Format_WithSystemMessage_ExtractsToSystemParameter()
+    {
+        // Arrange
+        var formatter = new AnthropicChatFormatter();
+        var messages = new List<Msg>
+        {
+            Msg.Builder().Role("system").TextContent("You are a helpful assistant.").Build(),
+            Msg.Builder().Role("user").TextContent("Hello!").Build()
+        };
+
+        // Act
+        var request = formatter.Format(messages);
+
+        // Assert
+        Assert.NotNull(request);
+        Assert.NotNull(request.System);
+        Assert.Single(request.System);
+        Assert.Equal("You are a helpful assistant.", request.System[0].Text);
+        Assert.Single(request.Messages); // System message removed from messages list
+    }
+
+    [Fact]
+    public void Format_WithOptions_AppliesOptions()
+    {
+        // Arrange
+        var formatter = new AnthropicChatFormatter();
+        var messages = new List<Msg>
+        {
+            Msg.Builder().Role("user").TextContent("Hello!").Build()
+        };
+        var options = new GenerateOptions
+        {
+            Temperature = 0.7,
+            MaxTokens = 1000,
+            TopP = 0.9,
+            TopK = 50
+        };
+
+        // Act
+        var request = formatter.Format(messages, options);
+
+        // Assert
+        Assert.Equal(0.7, request.Temperature);
+        Assert.Equal(1000, request.MaxTokens);
+        Assert.Equal(0.9, request.TopP);
+        Assert.Equal(50, request.TopK);
+    }
+
+    [Fact]
+    public void Format_WithTools_AddsToolsToRequest()
+    {
+        // Arrange
+        var formatter = new AnthropicChatFormatter();
+        var messages = new List<Msg>
+        {
+            Msg.Builder().Role("user").TextContent("Calculate 1 + 1").Build()
+        };
+        var tools = new List<ToolSchema>
+        {
+            new()
+            {
+                Name = "calculator",
+                Description = "A simple calculator",
+                Parameters = new Dictionary<string, object>
+                {
+                    ["type"] = "object",
+                    ["properties"] = new Dictionary<string, object>(),
+                    ["required"] = new List<string>()
+                }
+            }
+        };
+        var options = new GenerateOptions
+        {
+            AdditionalBodyParams = new Dictionary<string, object> { ["tools"] = tools }
+        };
+
+        // Act
+        var request = formatter.Format(messages, options);
+
+        // Assert
+        Assert.NotNull(request.Tools);
+        Assert.Single(request.Tools);
+        Assert.Equal("calculator", request.Tools![0].Name);
+    }
+
+    #endregion
+
+    #region Parse Tests
+
+    [Fact]
+    public void Parse_TextResponse_ReturnsChatResponse()
+    {
+        // Arrange
+        var formatter = new AnthropicChatFormatter();
+        var response = new AnthropicResponse
+        {
+            Id = "msg_123",
+            Type = "message",
+            Role = AnthropicRole.Assistant,
+            Model = "claude-3-5-sonnet-20241022",
+            Content = new List<AnthropicContentBlock>
+            {
+                new Dto.TextBlock { Text = "Hello! How can I help you today?" }
+            },
+            Usage = new AnthropicUsage
+            {
+                InputTokens = 10,
+                OutputTokens = 20
+            }
+        };
+        var startTime = DateTime.UtcNow.AddSeconds(-1);
+
+        // Act
+        var result = formatter.Parse(response, startTime);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("msg_123", result.Id);
+        Assert.Equal("Hello! How can I help you today?", result.Content);
+        Assert.Equal("claude-3-5-sonnet-20241022", result.Model);
+        Assert.NotNull(result.Usage);
+        Assert.Equal(10, result.Usage!.InputTokens);
+        Assert.Equal(20, result.Usage.OutputTokens);
+    }
+
+    [Fact]
+    public void Parse_ToolUseResponse_ReturnsToolCalls()
+    {
+        // Arrange
+        var formatter = new AnthropicChatFormatter();
+        var response = new AnthropicResponse
+        {
+            Id = "msg_456",
+            Type = "message",
+            Role = AnthropicRole.Assistant,
+            Model = "claude-3-5-sonnet-20241022",
+            Content = new List<AnthropicContentBlock>
+            {
+                new Dto.ToolUseBlock
+                {
+                    Id = "toolu_123",
+                    Name = "calculator",
+                    Input = new Dictionary<string, object> { ["expression"] = "1 + 1" }
+                }
+            },
+            StopReason = "tool_use",
+            Usage = new AnthropicUsage
+            {
+                InputTokens = 15,
+                OutputTokens = 25
+            }
+        };
+        var startTime = DateTime.UtcNow.AddSeconds(-1);
+
+        // Act
+        var result = formatter.Parse(response, startTime);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result.ToolCalls);
+        Assert.Single(result.ToolCalls);
+        Assert.Equal("toolu_123", result.ToolCalls![0].Id);
+        Assert.Equal("calculator", result.ToolCalls[0].Name);
+    }
+
+    [Fact]
+    public void Parse_ThinkingBlock_ReturnsThinkingContent()
+    {
+        // Arrange
+        var formatter = new AnthropicChatFormatter();
+        var response = new AnthropicResponse
+        {
+            Id = "msg_789",
+            Type = "message",
+            Role = AnthropicRole.Assistant,
+            Model = "claude-3-opus-20240229",
+            Content = new List<AnthropicContentBlock>
+            {
+                new Dto.ThinkingBlock { Thinking = "Let me think about this..." },
+                new Dto.TextBlock { Text = "The answer is 42." }
+            },
+            Usage = new AnthropicUsage
+            {
+                InputTokens = 20,
+                OutputTokens = 30
+            }
+        };
+        var startTime = DateTime.UtcNow.AddSeconds(-1);
+
+        // Act
+        var result = formatter.Parse(response, startTime);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.NotNull(result.Metadata);
+        Assert.True(result.Metadata!.ContainsKey("thinking"));
+        Assert.Equal("Let me think about this...", result.Metadata["thinking"]);
+    }
+
+    #endregion
+
+    #region Interface Implementation Tests
+
+    [Fact]
+    public void Interface_Format_ReturnsListOfRequests()
+    {
+        // Arrange
+        IFormatter<AnthropicRequest, AnthropicResponse, GenerateOptions> formatter = 
+            new AnthropicChatFormatter("claude-3-5-sonnet-20241022");
+        var messages = new List<Msg>
+        {
+            Msg.Builder().Role("user").TextContent("Hello!").Build()
+        };
+
+        // Act
+        var result = formatter.Format(messages);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result);
+        Assert.Equal("claude-3-5-sonnet-20241022", result[0].Model);
+    }
+
+    [Fact]
+    public void Interface_ParseResponse_ReturnsModelResponse()
+    {
+        // Arrange
+        IFormatter<AnthropicRequest, AnthropicResponse, GenerateOptions> formatter = 
+            new AnthropicChatFormatter();
+        var response = new AnthropicResponse
+        {
+            Id = "msg_123",
+            Type = "message",
+            Role = AnthropicRole.Assistant,
+            Model = "claude-3-5-sonnet-20241022",
+            Content = new List<AnthropicContentBlock> { new Dto.TextBlock { Text = "Hi!" } },
+            Usage = new AnthropicUsage { InputTokens = 5, OutputTokens = 10 }
+        };
+        var startTime = DateTime.UtcNow.AddSeconds(-1);
+
+        // Act
+        var result = formatter.ParseResponse(response, startTime);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Hi!", result.Text);
+    }
+
+    #endregion
+
+    #region MessageConverter Tests
+
+    [Fact]
+    public void MessageConverter_UserMessage_ReturnsUserRole()
+    {
+        // Arrange
+        var messages = new List<Msg>
+        {
+            Msg.Builder().Role("user").TextContent("Hello!").Build()
+        };
+
+        // Act
+        var result = AnthropicMessageConverter.Convert(messages);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal(AnthropicRole.User, result[0].Role);
+    }
+
+    [Fact]
+    public void MessageConverter_AssistantMessage_ReturnsAssistantRole()
+    {
+        // Arrange
+        var messages = new List<Msg>
+        {
+            Msg.Builder().Role("assistant").TextContent("Hello there!").Build()
+        };
+
+        // Act
+        var result = AnthropicMessageConverter.Convert(messages);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal(AnthropicRole.Assistant, result[0].Role);
+    }
+
+    [Fact]
+    public void MessageConverter_ToolResultMessage_ReturnsUserRoleWithToolResult()
+    {
+        // Arrange
+        var messages = new List<Msg>
+        {
+            Msg.Builder()
+                .Role("tool")
+                .TextContent("42")
+                .AddMetadata("tool_call_id", "toolu_123")
+                .Build()
+        };
+
+        // Act
+        var result = AnthropicMessageConverter.Convert(messages);
+
+        // Assert
+        Assert.Single(result);
+        Assert.Equal(AnthropicRole.User, result[0].Role);
+        Assert.Single(result[0].Content);
+        Assert.IsType<Dto.ToolResultBlock>(result[0].Content[0]);
+    }
+
+    [Fact]
+    public void MessageConverter_ExtractSystemMessage_ReturnsSystemMessages()
+    {
+        // Arrange
+        var messages = new List<Msg>
+        {
+            Msg.Builder().Role("system").TextContent("You are helpful.").Build(),
+            Msg.Builder().Role("user").TextContent("Hello!").Build()
+        };
+
+        // Act
+        var systemMessages = AnthropicMessageConverter.ExtractSystemMessage(messages);
+
+        // Assert
+        Assert.NotNull(systemMessages);
+        Assert.Single(systemMessages);
+        Assert.Equal("You are helpful.", systemMessages![0].Text);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
- Add Anthropic DTO models (Request, Response, ContentBlock, Tool, etc.)
- Implement AnthropicMessageConverter for message format conversion
- Implement AnthropicResponseParser for response parsing
- Implement AnthropicBaseFormatter and AnthropicChatFormatter
- Support system message extraction (Anthropic-specific)
- Support tool calls and tool results
- Support thinking blocks (Claude 3.7 Sonnet extended thinking)
- Add 13 unit tests (all passing)
- Update IFormatter with ToolChoice and AdditionalBodyParams support
- Add ContentBlock and ChatResponse models

Java reference: io.agentscope.core.formatter.anthropic.* 1:1 functional parity with Java version